### PR TITLE
Add secret cache based controller

### DIFF
--- a/cmd/imagepull-controller-workshop/main.go
+++ b/cmd/imagepull-controller-workshop/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/oklog/run"
 	"github.com/sirupsen/logrus"
@@ -16,7 +17,8 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
-	"github.com/slok/imagepull-controller-workshop/internal/controller"
+	controllernamespace "github.com/slok/imagepull-controller-workshop/internal/controller/namespace"
+	controllersecretcache "github.com/slok/imagepull-controller-workshop/internal/controller/secretcache"
 	loglogrus "github.com/slok/imagepull-controller-workshop/internal/log/logrus"
 	storagekubernetes "github.com/slok/imagepull-controller-workshop/internal/storage/kubernetes"
 )
@@ -52,6 +54,7 @@ func Run(ctx context.Context, stdin io.Writer, stdout, stderr io.Reader) error {
 
 	// Create dependencies
 	k8sRepo := storagekubernetes.NewRepository(kcli)
+	cachedSecretK8sRepo := storagekubernetes.NewSecretCachedRepository(k8sRepo)
 
 	// Prepare our run entrypoints.
 	var g run.Group
@@ -78,42 +81,80 @@ func Run(ctx context.Context, stdin io.Writer, stdout, stderr io.Reader) error {
 		)
 	}
 
-	// Controllers.
+	// Main controller for namespaces.
 	{
 		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()
-		handler, err := controller.NewHandler(controller.HandlerConfig{
+		handler, err := controllernamespace.NewHandler(controllernamespace.HandlerConfig{
 			RunningNamespace:      cmdCfg.NamespaceRunning,
 			ImagePullSecretName:   cmdCfg.SecretName,
 			SaImagePullSecretName: cmdCfg.SaSecretName,
-			K8sRepo:               k8sRepo,
+			K8sRepo:               cachedSecretK8sRepo,
 			Logger:                logger,
 		})
 		if err != nil {
-			return fmt.Errorf("could not create controller handler: %w", err)
+			return fmt.Errorf("could not create namespace controller handler: %w", err)
 		}
 
-		retriever, err := controller.NewRetriever(k8sRepo, logger)
+		retriever, err := controllernamespace.NewRetriever(k8sRepo)
 		if err != nil {
-			return fmt.Errorf("could not create controller retriever: %w", err)
+			return fmt.Errorf("could not create namespace controller retriever: %w", err)
 		}
 
-		ctrlNs, err := koopercontroller.New(&koopercontroller.Config{
+		ctrl, err := koopercontroller.New(&koopercontroller.Config{
 			Handler:              handler,
 			Retriever:            retriever,
 			Logger:               kooperLogger,
-			Name:                 "imagepull-workshop-controller-ns",
+			Name:                 "imagepull-workshop-namespace",
 			ConcurrentWorkers:    cmdCfg.Workers,
 			ProcessingJobRetries: 2,
 			ResyncInterval:       cmdCfg.ResyncInterval,
 		})
 		if err != nil {
-			return fmt.Errorf("could not create backend auth kubernetes controller: %w", err)
+			return fmt.Errorf("could not create namespace controller: %w", err)
 		}
 
 		g.Add(
 			func() error {
-				return ctrlNs.Run(ctx)
+				return ctrl.Run(ctx)
+			},
+			func(_ error) {
+				cancel()
+			},
+		)
+	}
+
+	// Secret cache controller optimization.
+	{
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		handler, err := controllersecretcache.NewHandler(cachedSecretK8sRepo, logger)
+		if err != nil {
+			return fmt.Errorf("could not create secret cache controller handler: %w", err)
+		}
+
+		retriever, err := controllersecretcache.NewRetriever(k8sRepo, cmdCfg.NamespaceRunning, cmdCfg.SecretName)
+		if err != nil {
+			return fmt.Errorf("could not create secret cache controller retriever: %w", err)
+		}
+
+		ctrl, err := koopercontroller.New(&koopercontroller.Config{
+			Handler:              handler,
+			Retriever:            retriever,
+			Logger:               kooperLogger,
+			Name:                 "imagepull-workshop-secret-cache",
+			ConcurrentWorkers:    1,
+			ProcessingJobRetries: 1,
+			ResyncInterval:       5 * time.Minute,
+		})
+		if err != nil {
+			return fmt.Errorf("could not create secret cache controller: %w", err)
+		}
+
+		g.Add(
+			func() error {
+				return ctrl.Run(ctx)
 			},
 			func(_ error) {
 				cancel()

--- a/internal/controller/namespace/retrieve.go
+++ b/internal/controller/namespace/retrieve.go
@@ -1,4 +1,4 @@
-package controller
+package namespace
 
 import (
 	"context"
@@ -9,18 +9,16 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
-
-	"github.com/slok/imagepull-controller-workshop/internal/log"
 )
 
-// RetrieverKubernetesRepository is the service to manage k8s resources by the Kubernetes retrievers.
-type RetrieverKubernetesRepository interface {
+// RetrieverRepository is the service to manage k8s resources by the Kubernetes retrievers.
+type RetrieverRepository interface {
 	ListNamespaces(ctx context.Context, labelSelector map[string]string) (*corev1.NamespaceList, error)
 	WatchNamespaces(ctx context.Context, labelSelector map[string]string) (watch.Interface, error)
 }
 
 // NewRetriever returns the retriever for the controller.
-func NewRetriever(k8sRepo RetrieverKubernetesRepository, logger log.Logger) (controller.Retriever, error) {
+func NewRetriever(k8sRepo RetrieverRepository) (controller.Retriever, error) {
 	return controller.RetrieverFromListerWatcher(&cache.ListWatch{
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 			return k8sRepo.ListNamespaces(context.Background(), map[string]string{})

--- a/internal/controller/secretcache/handle.go
+++ b/internal/controller/secretcache/handle.go
@@ -1,0 +1,50 @@
+package secretcache
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spotahome/kooper/v2/controller"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/slok/imagepull-controller-workshop/internal/log"
+)
+
+// HandlerRepository is the service to manage k8s resources by the Kubernetes controller handler.
+type HandlerRepository interface {
+	SetSecretOnCache(ctx context.Context, secret *corev1.Secret) error
+}
+
+type handler struct {
+	k8sRepo HandlerRepository
+	logger  log.Logger
+}
+
+// NewHandler returns the handler for the controller.
+func NewHandler(k8sRepo HandlerRepository, logger log.Logger) (controller.Handler, error) {
+	return handler{
+		k8sRepo: k8sRepo,
+		logger:  logger.WithValues(log.Kv{"svc": "controller.secretcache.Handler"}),
+	}, nil
+}
+
+func (h handler) Handle(ctx context.Context, obj runtime.Object) error {
+	secret, ok := obj.(*corev1.Secret)
+	if !ok {
+		h.logger.Warningf("controller received object that is not a secret")
+		return nil
+	}
+
+	logger := h.logger.WithValues(log.Kv{"k8s-ns": secret.Namespace, "k8s-name": secret.Name})
+
+	// Store on cache.
+	err := h.k8sRepo.SetSecretOnCache(ctx, secret)
+	if err != nil {
+		return fmt.Errorf("could not update secret cache: %w", err)
+	}
+
+	logger.Infof("Secret cache updated")
+
+	return nil
+}

--- a/internal/controller/secretcache/retrieve.go
+++ b/internal/controller/secretcache/retrieve.go
@@ -1,0 +1,35 @@
+package secretcache
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spotahome/kooper/v2/controller"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+)
+
+// RetrieverRepository is the service to manage k8s resources by the Kubernetes retrievers.
+type RetrieverRepository interface {
+	ListSecrets(ctx context.Context, ns string, options metav1.ListOptions) (*corev1.SecretList, error)
+	WatchSecrets(ctx context.Context, ns string, options metav1.ListOptions) (watch.Interface, error)
+}
+
+// NewRetriever returns the retriever for the controller.
+func NewRetriever(k8sRepo RetrieverRepository, ns, secretName string) (controller.Retriever, error) {
+	secretFieldSelector := fmt.Sprintf("metadata.name=%s", secretName)
+
+	return controller.RetrieverFromListerWatcher(&cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			options.FieldSelector = secretFieldSelector
+			return k8sRepo.ListSecrets(context.Background(), ns, options)
+		},
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			options.FieldSelector = secretFieldSelector
+			return k8sRepo.WatchSecrets(context.Background(), ns, options)
+		},
+	})
+}

--- a/internal/storage/kubernetes/kubernetes.go
+++ b/internal/storage/kubernetes/kubernetes.go
@@ -42,6 +42,16 @@ func (r Repository) GetSecret(ctx context.Context, ns string, name string) (*cor
 	return r.kcli.CoreV1().Secrets(ns).Get(ctx, name, metav1.GetOptions{})
 }
 
+// ListSecrets lists Kubernetes secrets from Kubernetes API server.
+func (r Repository) ListSecrets(ctx context.Context, ns string, options metav1.ListOptions) (*corev1.SecretList, error) {
+	return r.kcli.CoreV1().Secrets(ns).List(ctx, options)
+}
+
+// WatchSecrets watchs Kubernetes secrets from Kubernetes API server.
+func (r Repository) WatchSecrets(ctx context.Context, ns string, options metav1.ListOptions) (watch.Interface, error) {
+	return r.kcli.CoreV1().Secrets(ns).Watch(ctx, options)
+}
+
 // EnsureSecret will create the secret if is missing and overwrite if already exists.
 func (r Repository) EnsureSecret(ctx context.Context, secret *corev1.Secret) error {
 	storedSecret, err := r.kcli.CoreV1().Secrets(secret.Namespace).Get(ctx, secret.Name, metav1.GetOptions{})

--- a/internal/storage/kubernetes/secretcache.go
+++ b/internal/storage/kubernetes/secretcache.go
@@ -1,0 +1,50 @@
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// SecretCachedRepository is a Kubernetes repository like `Repository` but getting a
+// secret is done from an internal cache.
+type SecretCachedRepository struct {
+	mu      sync.RWMutex
+	secrets map[string]*corev1.Secret
+	Repository
+}
+
+// NewSecretCachedRepository returns a new NewSecretCachedRepository.
+func NewSecretCachedRepository(repo Repository) *SecretCachedRepository {
+	return &SecretCachedRepository{
+		Repository: repo,
+		secrets:    map[string]*corev1.Secret{},
+	}
+}
+
+// GetSecret will return a secret from the internal cache.
+func (s *SecretCachedRepository) GetSecret(ctx context.Context, ns string, name string) (*corev1.Secret, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	id := fmt.Sprintf("%s/%s", ns, name)
+	secret, ok := s.secrets[id]
+	if !ok {
+		return nil, fmt.Errorf("secret not found")
+	}
+
+	// Deep copy because we don't want cache object mutations from the outside.
+	return secret.DeepCopy(), nil
+}
+
+// SetSecretOnCache sets a new secret on the repository cache.
+func (s *SecretCachedRepository) SetSecretOnCache(ctx context.Context, secret *corev1.Secret) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	id := fmt.Sprintf("%s/%s", secret.Namespace, secret.Name)
+	s.secrets[id] = secret
+
+	return nil
+}


### PR DESCRIPTION
Before this PR on the namespace handling prior to cloning the secret, we get the secret every time. With this Pr now it uses an internal cache for the cache updates. This cache is populated with a second controller that listens to changes on the observed Secret.